### PR TITLE
Allow for overriding the SynthDef name by using the `\instrument` key.

### DIFF
--- a/VoicerNode.sc
+++ b/VoicerNode.sc
@@ -81,7 +81,7 @@ SynthVoicerNode {
 	// testArgClass { |argValue| ^argValue.asTestUGenInput.isValidSynthArg }
 
 	triggerMsg { arg freq, gate = 1, args;
-		var bundle, args2;
+		var bundle, args2, defname2;
 		// create osc message
 		bundle = List.new;
 		// assemble arguments
@@ -94,8 +94,14 @@ SynthVoicerNode {
 		};
 		(args.at(0).notNil).if({ args2 = args2 ++ args });
 		freq.notNil.if({ args2 = args2 ++ [\freq, freq] });
+		// override SynthDef name
+		if(args2.includes(\instrument), {
+			defname2 = args2.asDict.at(\instrument);
+		}, {
+			defname2 = defname;
+		});
 		// make synth object
-		synth = Synth.basicNew(defname, target.server);
+		synth = Synth.basicNew(defname2, target.server);
 		bundle.add(synth.newMsg(target, args2.asOSCArgArray ++ this.mapArgs
 			++ [\out, bus.index, \outbus, bus.index], addAction));
 		^bundle


### PR DESCRIPTION
For normal SynthDefs this patch seems to work. I tried with:
```
// assume a SynthDef named \saw exists
(
v = Voicer.new(20, \default);
k = VoicerMIDISocket([\all, \omni], v);
k.noteOnArgsPat = Pbind(
	\instrument, Pseq([\default, \saw], inf) // Change synth every note
);
)
```
I havent thought about `Instr` at all.